### PR TITLE
Client with new did creation and json-ld issuance

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,14 +1,20 @@
 openapi: 3.0.1
 info:
   title: Edison Credentials API
+  description: "Create and manage organizations, connect to other agents, issue and\
+    \ verify credentials"
   version: 0.0.1
 servers:
-- url: /edison-credentials-api
+- url: /
 tags:
 - name: Revocations
   description: Revoke issued credentials
 - name: Webhooks
   description: The Webhooks API
+- name: Credentials Signing
+  description: Sign credentials and returns the signed credential or an error msg.
+- name: Credentials Send
+  description: Send credentials and retrieve issued credentials.
 - name: Credential Definitions
   description: Create and retrieve credential definitions
 - name: Connections
@@ -729,6 +735,47 @@ paths:
                 $ref: '#/components/schemas/VerificationTemplate'
       security:
       - auth: []
+  /sign-credential:
+    post:
+      tags:
+      - Credentials Signing
+      summary: Sign a credential
+      description: Sign a credential
+      operationId: signCredential
+      parameters:
+      - name: X-ORGANIZATION-ID
+        in: header
+        required: true
+        schema:
+          type: integer
+          format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LDCredentialSigning'
+        required: true
+      responses:
+        "500":
+          description: Internal Server Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SignedDocResponse'
+      security:
+      - auth: []
   /schemas:
     post:
       tags:
@@ -869,6 +916,90 @@ paths:
                 $ref: '#/components/schemas/Organization'
       security:
       - auth: []
+  /organizations/{organizationId}/issuance-dids:
+    get:
+      tags:
+      - Organizations
+      summary: Retrieve public DIDs for a given organization.
+      description: "Retrieve public DIDs along with their status regarding ledger\
+        \ writes. DIDs in state READY_TO_WRITE are fully ready to operate on the ledger\
+        \ (publish schemas, credential definitions, etc.)"
+      operationId: listOrganizationDids
+      parameters:
+      - name: organizationId
+        in: path
+        description: An organization ID.
+        required: true
+        schema:
+          type: integer
+          format: int32
+        example: 0
+      responses:
+        "500":
+          description: Internal Server Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/IssuanceDid'
+      security:
+      - auth: []
+    post:
+      tags:
+      - Organizations
+      summary: Create a new issuance DID for a given organization.
+      description: "Create a new issuance DID. If it's a did:sov, get it endorsed\
+        \ automatically."
+      operationId: createIssuanceDid
+      parameters:
+      - name: organizationId
+        in: path
+        description: An organization ID.
+        required: true
+        schema:
+          type: integer
+          format: int32
+        example: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DidCreationRequest'
+        required: true
+      responses:
+        "500":
+          description: Internal Server Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssuanceDid'
+      security:
+      - auth: []
   /messages:
     post:
       tags:
@@ -903,6 +1034,85 @@ paths:
                 $ref: '#/components/schemas/ApiError'
         "204":
           description: No Content
+      security:
+      - auth: []
+  /credentials-send:
+    get:
+      tags:
+      - Credentials Send
+      summary: List all credentials
+      description: List all credentials sent by an organization
+      operationId: listCredentialSent
+      parameters:
+      - name: X-ORGANIZATION-ID
+        in: header
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "500":
+          description: Internal Server Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CredentialSent'
+      security:
+      - auth: []
+    post:
+      tags:
+      - Credentials Send
+      summary: Send a new credential
+      description: "(ASYNC) Send a new credential. This operation is asynchronous,\
+        \ to follow the progress of the issuance, use webhooks or check the issuance\
+        \ status using the API."
+      operationId: sendCredential
+      parameters:
+      - name: X-ORGANIZATION-ID
+        in: header
+        required: true
+        schema:
+          type: integer
+          format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LDCredentialSending'
+        required: true
+      responses:
+        "500":
+          description: Internal Server Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CredentialSent'
       security:
       - auth: []
   /credentials-issuance:
@@ -1349,86 +1559,6 @@ paths:
                   $ref: '#/components/schemas/SchemaSummary'
       security:
       - auth: []
-  /organizations/{organizationId}/issuance-dids:
-    get:
-      tags:
-      - Organizations
-      summary: Retrieve public DIDs for a given organization.
-      description: "Retrieve public DIDs along with their status regarding ledger\
-        \ writes. DIDs in state READY_TO_WRITE are fully ready to operate on the ledger\
-        \ (publish schemas, credential definitions, etc.)"
-      operationId: listOrganizationDids
-      parameters:
-      - name: organizationId
-        in: path
-        description: An organization ID.
-        required: true
-        schema:
-          type: integer
-          format: int32
-        example: 0
-      responses:
-        "500":
-          description: Internal Server Error
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ApiError'
-        "400":
-          description: Bad Request
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ApiError'
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Did'
-      security:
-      - auth: []
-  /organizations/{organizationId}/endorse:
-    get:
-      tags:
-      - Organizations
-      summary: Request endorsement. Mandatory for issuers.
-      description: "(ASYNC) Request for endorsement of the organization transactions.\
-        \ Mandatory for issuers. This is an asynchronous operation, to follow progress,\
-        \ use webhooks or check the public DID status from the API."
-      operationId: endorseOrganization
-      parameters:
-      - name: organizationId
-        in: path
-        description: An organization ID.
-        required: true
-        schema:
-          type: integer
-          format: int32
-        example: 0
-      responses:
-        "500":
-          description: Internal Server Error
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ApiError'
-        "400":
-          description: Bad Request
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ApiError'
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PublicDid'
-      security:
-      - auth: []
   /credentials:
     get:
       tags:
@@ -1541,6 +1671,48 @@ paths:
                 $ref: '#/components/schemas/ApiError'
         "204":
           description: No Content
+      security:
+      - auth: []
+  /credentials-send/{sendId}:
+    get:
+      tags:
+      - Credentials Send
+      summary: Get a credential send
+      description: Get the specified credential sent. Can be used to check on the
+        sending state.
+      operationId: getCredentialSendById
+      parameters:
+      - name: X-ORGANIZATION-ID
+        in: header
+        required: true
+        schema:
+          type: integer
+          format: int32
+      - name: sendId
+        in: path
+        description: An credential sent ID.
+        required: true
+        schema:
+          type: string
+      responses:
+        "500":
+          description: Internal Server Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CredentialSent'
       security:
       - auth: []
   /credentials-issuance/{issuanceId}:
@@ -1784,6 +1956,12 @@ paths:
 components:
   schemas:
     ApiError:
+      required:
+      - error
+      - message
+      - path
+      - status
+      - timestamp
       type: object
       properties:
         timestamp:
@@ -1906,6 +2084,9 @@ components:
           description: The webhook type description
       description: List of filters available
     RequestedAttribute:
+      required:
+      - names
+      - restrictions
       type: object
       properties:
         names:
@@ -1924,6 +2105,11 @@ components:
       description: "The requested attributes. In order for the verification to be\
         \ successful, all requested attribute should be validated"
     RequestedPredicate:
+      required:
+      - name
+      - predicateType
+      - predicateValue
+      - restrictions
       type: object
       properties:
         name:
@@ -1949,6 +2135,8 @@ components:
       description: "The requested predicates. In order for the verification to be\
         \ successful, all requested predicates should be validated"
     Restriction:
+      required:
+      - credentialDefinitionId
       type: object
       properties:
         credentialDefinitionId:
@@ -1969,6 +2157,9 @@ components:
           type: boolean
           description: Defines if the credential should be valid at the current date
     VerificationTemplateContent:
+      required:
+      - requestedAttributes
+      - requestedPredicates
       type: object
       properties:
         requestedAttributes:
@@ -2026,16 +2217,28 @@ components:
         name:
           type: string
           description: The organization name
-        issuer:
-          type: boolean
-          description: Defines if the organization can issue credentials
         imageUrl:
           type: string
           description: The image url of the Organization
+    IssuanceDid:
+      required:
+      - did
+      - verificationKey
+      type: object
+      properties:
+        did:
+          type: string
+        verificationKey:
+          type: string
+        endorsementStatus:
+          type: string
+      description: Public did if applicable
+      nullable: true
     Organization:
       required:
       - clientId
       - id
+      - issuanceDids
       - name
       type: object
       properties:
@@ -2053,19 +2256,12 @@ components:
         imageUrl:
           type: string
           description: The image url of the Organization
-        publicDid:
-          $ref: '#/components/schemas/PublicDid'
-    PublicDid:
-      type: object
-      properties:
-        did:
-          type: string
-        verificationKey:
-          type: string
-        endorsementStatus:
-          type: string
-      description: Public did if applicable
-      nullable: true
+        issuanceDids:
+          type: array
+          description: Public did if applicable
+          nullable: true
+          items:
+            $ref: '#/components/schemas/IssuanceDid'
     WebhookCreate:
       required:
       - active
@@ -2108,6 +2304,13 @@ components:
           type: string
           description: An optional comment
     Verification:
+      required:
+      - connectionId
+      - createdAt
+      - state
+      - updatedAt
+      - verificationId
+      - verificationRequest
       type: object
       properties:
         verificationId:
@@ -2137,6 +2340,10 @@ components:
           description: The update date
           format: date-time
     VerificationRequest:
+      required:
+      - name
+      - requestedAttributes
+      - requestedPredicates
       type: object
       properties:
         name:
@@ -2168,6 +2375,37 @@ components:
           description: The verificationTemplate name
         content:
           $ref: '#/components/schemas/VerificationTemplateContent'
+    LDCredentialSigning:
+      required:
+      - credential
+      - proofType
+      - revocable
+      - verificationMethod
+      type: object
+      properties:
+        credential:
+          type: object
+          description: Credential
+        proofType:
+          type: string
+          description: Key type "ed25519" or "bls12381g2"
+          enum:
+          - ed25519
+          - bls12381g2
+        verificationMethod:
+          type: string
+          description: Verification method
+        revocable:
+          type: boolean
+    SignedDocResponse:
+      type: object
+      properties:
+        errorMsg:
+          type: string
+          description: Description of the error in case it happens
+        signedDoc:
+          type: object
+          description: Document signed
     SchemaCreate:
       required:
       - attributesName
@@ -2225,6 +2463,21 @@ components:
         imageUrl:
           type: string
           description: The image url of the Organization
+    DidCreationRequest:
+      required:
+      - keyType
+      - method
+      type: object
+      properties:
+        method:
+          type: string
+          description: The did method to use
+        keyType:
+          type: string
+          description: The key type to use
+        did:
+          type: string
+          description: The did to use (if applicable)
     Message:
       required:
       - connectionId
@@ -2236,7 +2489,31 @@ components:
         connectionId:
           pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           type: string
+    LDCredentialSending:
+      required:
+      - connectionId
+      - credential
+      - proofType
+      type: object
+      properties:
+        credential:
+          type: object
+          description: Credential
+        proofType:
+          type: string
+          description: Key type "ed25519" or "bls12381g2"
+          enum:
+          - ed25519
+          - bls12381g2
+        connectionId:
+          pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          type: string
+          description: The connection id
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
     CredentialAttribute:
+      required:
+      - name
+      - value
       type: object
       properties:
         name:
@@ -2249,6 +2526,49 @@ components:
           type: string
           description: An optional credential mime type
       description: A list of credential attributes
+    CredentialProposal:
+      required:
+      - attributes
+      type: object
+      properties:
+        attributes:
+          type: array
+          description: A list of credential attributes
+          items:
+            $ref: '#/components/schemas/CredentialAttribute'
+    CredentialSent:
+      required:
+      - credential
+      - issuanceId
+      - state
+      type: object
+      properties:
+        issuanceId:
+          type: string
+          description: A credential issuance ID
+        errorMessage:
+          type: string
+          description: Optional error message
+        state:
+          type: string
+          description: State of the credential transaction
+        updatedAt:
+          type: string
+          format: date-time
+        credential:
+          $ref: '#/components/schemas/SendingCredentialResponse'
+    SendingCredentialResponse:
+      required:
+      - credentialProposal
+      type: object
+      properties:
+        credentialId:
+          type: string
+        comment:
+          type: string
+          description: A human readable comment
+        credentialProposal:
+          $ref: '#/components/schemas/CredentialProposal'
     CredentialCreate:
       required:
       - attributes
@@ -2279,6 +2599,8 @@ components:
           items:
             $ref: '#/components/schemas/CredentialAttribute'
     Credential:
+      required:
+      - credentialProposal
       type: object
       properties:
         credentialId:
@@ -2317,14 +2639,6 @@ components:
           format: date-time
         credential:
           $ref: '#/components/schemas/Credential'
-    CredentialProposal:
-      type: object
-      properties:
-        attributes:
-          type: array
-          description: A list of credential attributes
-          items:
-            $ref: '#/components/schemas/CredentialAttribute'
     CredentialDefinitionCreate:
       required:
       - schemaId
@@ -2370,7 +2684,6 @@ components:
       required:
       - invitationId
       - recipientKeys
-      - routingKeys
       - serviceEndpoint
       type: object
       properties:
@@ -2445,17 +2758,22 @@ components:
           - ERROR
           - INACTIVE
     VerificationSummary:
+      required:
+      - name
+      - verificationId
       type: object
       properties:
-        name:
-          type: string
-          description: The name of the validation
-          example: example
         verificationId:
           type: string
           description: The verification id
           example: ac32f24e-2f90-4e90-9427-c59482078a4b
+        name:
+          type: string
+          description: The name of the validation
+          example: example
     VerificationTemplateSummary:
+      required:
+      - name
       type: object
       properties:
         id:
@@ -2497,6 +2815,9 @@ components:
           type: boolean
           description: Whether the schema is anchored or not
     OrganizationSummary:
+      required:
+      - id
+      - name
       type: object
       properties:
         id:
@@ -2505,21 +2826,6 @@ components:
         name:
           type: string
         imgUrl:
-          type: string
-    Did:
-      type: object
-      properties:
-        value:
-          pattern: "^(did:sov:)?[1-9A-HJ-NP-Za-km-z]{21,22}$"
-          type: string
-        status:
-          type: string
-          enum:
-          - PUBLIC
-          - POSTED
-          - WALLET_ONLY
-          - UNKNOW
-        verificationKey:
           type: string
     CredentialDefinition:
       required:

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <groupId>com.sicpa.edison</groupId>
         <artifactId>edison-credentials-client</artifactId>
-        <artifactVersion>0.0.49</artifactVersion>
+        <artifactVersion>0.0.50</artifactVersion>
         <!-- used to configure the SCM (releases) -->
         <github.repository>sicpa-dlab/edison-credentials-client</github.repository>
         <!--


### PR DESCRIPTION
Client with the additions of:
* new `/issuance-did` endpoints to create and list public dids of all supported types
* new endpoints to sign and send json-ld credentials